### PR TITLE
feat: library entry funcs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,6 @@ rpds = { version = "*", features = ["serde"] }
 rustc_tools_util = "*"
 petgraph = "*"
 shellwords = "*"
+
+[package.metadata.rust-analyzer]
+rustc_private = true

--- a/src/mir/mod.rs
+++ b/src/mir/mod.rs
@@ -3,4 +3,5 @@ pub mod context;
 pub mod function;
 pub mod analysis_context;
 pub mod known_names;
+mod visibility;
 pub mod path;

--- a/src/mir/visibility.rs
+++ b/src/mir/visibility.rs
@@ -1,0 +1,30 @@
+//! Utilities of resolving visibility issues.
+
+use rustc_hir::def::DefKind;
+use rustc_hir::def_id::DefId;
+use rustc_middle::ty::TyCtxt;
+use std::collections::HashSet;
+
+pub(crate) fn is_reachable(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
+    match def_id.as_local() {
+        Some(def_id) => tcx.effective_visibilities(()).is_reachable(def_id),
+        None => false,
+    }
+}
+
+pub(crate) fn lib_entry_funcs<'tcx>(tcx: TyCtxt<'tcx>) -> HashSet<DefId> {
+    let mut set = HashSet::new();
+    for item in tcx.hir_crate_items(()).items() {
+        let def_id = item.owner_id.def_id.to_def_id();
+        match tcx.def_kind(def_id) {
+            // XXX: make sure those cover all possible entries for call graph construction
+            DefKind::AssocFn | DefKind::Fn => {
+                if is_reachable(tcx, def_id) {
+                    set.insert(def_id);
+                }
+            }
+            _ => {}
+        }
+    }
+    set
+}

--- a/src/pta/andersen.rs
+++ b/src/pta/andersen.rs
@@ -84,9 +84,12 @@ impl<'pta, 'tcx, 'compilation> AndersenPTA<'pta, 'tcx, 'compilation> {
     /// Initialize the analysis.
     pub fn initialize(&mut self) {
         // add the entry point to the call graph
-        let entry_point = self.acx.entry_point;
-        let entry_func_id = self.acx.get_func_id(entry_point, self.tcx().mk_args(&[]));
-        self.call_graph.add_node(entry_func_id);
+        let entry_points = self.acx.entry_points.clone();
+
+        for entry_point in entry_points {
+            let entry_func_id = self.acx.get_func_id(entry_point, self.tcx().mk_args(&[]));
+            self.call_graph.add_node(entry_func_id);
+        }
 
         // process statements of reachable functions
         self.process_reach_funcs();

--- a/src/pta/context_sensitive.rs
+++ b/src/pta/context_sensitive.rs
@@ -110,10 +110,13 @@ impl<'pta, 'tcx, 'compilation, S: ContextStrategy> ContextSensitivePTA<'pta, 'tc
     /// Initialize the analysis.
     pub fn initialize(&mut self) {
         // add the entry point to the call graph
-        let entry_point = self.acx.entry_point;
         let empty_context_id = self.get_empty_context_id();
-        let entry_func_id = self.acx.get_func_id(entry_point, self.tcx().mk_args(&[]));
-        self.call_graph.add_node(CSFuncId::new(empty_context_id, entry_func_id));
+        let entry_points = self.acx.entry_points.clone();
+        for entry_point in entry_points {
+            let entry_func_id = self.acx.get_func_id(entry_point, self.tcx().mk_args(&[]));
+            self.call_graph
+                .add_node(CSFuncId::new(empty_context_id, entry_func_id));
+        }
 
         // process statements of reachable functions
         self.process_reach_funcs();


### PR DESCRIPTION
Add a feature: when the crate being analyzed is a library and no entry function is provided, the analyzer will include all public interface functions of the library in the entry function list and start the analysis.

Please feel free to push to this fork to update it.